### PR TITLE
Fix Google sign-in session handling and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Public Firebase configuration
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+
+# Service account JSON for server-side SDK (newlines in private_key must be escaped)
+FIREBASE_SERVICE_ACCOUNT='{"type":"service_account","project_id":"your-project-id","private_key_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n","client_email":"firebase-adminsdk@your-project.iam.gserviceaccount.com","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk%40your-project.iam.gserviceaccount.com"}'

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -49,7 +49,20 @@ export default function LoginPage() {
   const handleGoogleSignIn = async () => {
     try {
         await signInWithGoogle();
-        router.push("/");
+        const idToken = await auth.currentUser?.getIdToken();
+        const response = await fetch('/api/auth/login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ idToken }),
+        });
+
+        if (response.ok) {
+            router.push("/");
+        } else {
+            throw new Error("Falha ao criar sessão");
+        }
     } catch (error) {
         toast({
             variant: "destructive",
@@ -61,11 +74,8 @@ export default function LoginPage() {
 
   const onSubmit = async (data: z.infer<typeof FormSchema>) => {
     try {
-        console.log('Login')
         await signInWithEmail(data.email, data.password);
         const idToken = await auth.currentUser?.getIdToken();
-        idToken
-        console.log('idToken', idToken)
         const response = await fetch('/api/auth/login', {
             method: 'POST',
             headers: {
@@ -73,8 +83,6 @@ export default function LoginPage() {
             },
             body: JSON.stringify({ idToken }),
         });
-
-        console.log('response', response)
 
         if (response.ok) {
             router.push("/");


### PR DESCRIPTION
## Summary
- ensure Google sign-in exchanges ID token for a session
- document required Firebase environment variables

## Testing
- `npm run typecheck` *(fails: Property 'userId' is missing in type ...)*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6890d8c315c88324a26cdb072294d9c5